### PR TITLE
Descriptions and change category_group name

### DIFF
--- a/midterm-group.Rmd
+++ b/midterm-group.Rmd
@@ -26,23 +26,7 @@ The record-level file with all new and modified variables included.
 An updated Data Documentation that describes the new variables and, if necessary, modifies the description of any already existing variables.
 Annotated R syntax clearly articulating steps for all data cleaning and variable creation. This should be efficient and complete such that the code could be run all at once on raw data to recreate the updated data set.
 Link to Boston Data Library: https://dataverse.harvard.edu/dataverse/BARI
-Place_id: a textual identifier that uniquely identifies a place
-Name: contains the human-readable name for the returned result
-Vicinity: lists a simplified address for the place, including the street name, street number, and locality, but not the province/state, postal code, or country
-Tag_X (where X=1,...,10): string containing place details restricted to 100 different tags such as health, zoo, car_dealership, and lawyer
-X: contains longitude coordinate, expressed in degrees
-Y: contains latitude coordinate, expressed in degrees
-Place_geog: it represents values which connect geographical coordinates and block_ID in the dataset
-Place_geog_type: the place_geog value for each location is represented by 2 values: the land parcel ID (Ln_P_ID) and the Location ID (LOC_ID)
-Blk_ID_10: numeric variables with 15 digits which contained the corresponding State, County, Tract and Block ID's
-State: the first 2 digits of the Blk_ID_10 variable represents the State code.
-County: the 3rd digit to the 5th digit of the Blk_ID_10 variable represents the County code.
-Tract_Group: the 6rd digit to the 11th digit of the Blk_ID_10 variable represents the Tract_Group code.
-Block_Group: the 12th digit to the 15th digit of the Blk_ID_10 variable represents the Block_Group code.
-Area: String describing the name of the area/city derived from 'vicinity'
-Street: String describing the name of the Street derived from 'vicinity'
-Bucket_vicinity: The specific area either ‘Boston’, ‘Greater_MA’, ‘Greater_Boston’, or ‘Outside_MA/Unclear’ based on the city or part of city listed in the vicinity column. 
-Category_group: String generalizing the information in 
+
 
 
 ```{r, echo=FALSE}
@@ -76,7 +60,7 @@ data['category_group'] <- ifelse(c(data$Tag_1=='restaurant'|data$Tag_1=='meal_de
                                           ifelse(c(data$Tag_1=='campground'|data$Tag_1=='lodging'|data$Tag_1=='rv_park'),'lodging',
                                                  ifelse(c(data$Tag_1=='school'|data$Tag_1=='secondary_school'|data$Tag_1=='primary_school'|data$Tag_1=='university'),'education',
                                                         ifelse(c(data$Tag_1=='cemetery'|data$Tag_1=='embassy'),'other',
-                                                               ifelse(c(data$Tag_1=='parking'|data$Tag_1=='taxi_stand'|data$Tag_1=='bus_station'|data$Tag_1=='transit_station'|data$Tag_1=='train_station'|data$Tag_1=='subway_station'),'transportation','no_tag'))))))))))
+                                                               ifelse(c(data$Tag_1=='parking'|data$Tag_1=='taxi_stand'|data$Tag_1=='bus_station'|data$Tag_1=='transit_station'|data$Tag_1=='train_station'|data$Tag_1=='subway_station'),'parking_transportation','no_tag'))))))))))
 
 
 


### PR DESCRIPTION
The descriptions of the variables have been taken out and put into a separate file which I am going to upload onto this site and update in the shared google doc. They should be in their own separate document. I changed 'transportation' to 'parking_transportation' because parking is included in the grouping and I thought that was important to include in the name. You can change it back if you want.